### PR TITLE
.bash_profile: prefer python venv for Zephyr RTOS environment

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -87,9 +87,15 @@ zephyr() {
        _zephyr_dir="$HOME/Projects/zephyrproject/zephyr"
     fi
 
-    if [ -f "$_zephyr_dir/zephyr-env.sh" ]; then
+    if [ -f "$_zephyr_dir/../venv/bin/activate" ]; then
+        source "$_zephyr_dir/../venv/bin/activate"
+    elif [ -f "$_zephyr_dir/zephyr-env.sh" ]; then
         source "$_zephyr_dir/zephyr-env.sh"
     fi
+
+    pushd $_zephyr_dir
+
+    eval "$(west completion bash)"
 }
 
 zame() {


### PR DESCRIPTION
Change the zephyr() environment setup function to favor using a Python
virtual environment. Automatically evaluate the west bash completion.